### PR TITLE
Add background and intent options to CLI, Node, and browser interfaces

### DIFF
--- a/example/example.ts
+++ b/example/example.ts
@@ -19,7 +19,11 @@ async function runExample() {
     const pdfBuffer = fs.readFileSync(PDF_FILE);
 
     // Convert PDF to images
-    const images = await pdfToImg(pdfBuffer, { scale: 2 });
+    const images = await pdfToImg(pdfBuffer, {
+      scale: 2,
+      background: "white",
+      intent: "print",
+    });
 
     // Save images
     await Promise.all(

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -59,7 +59,12 @@ async function pageToImg(
   canvas.height = viewport.height;
   canvas.width = viewport.width;
 
-  const renderTask = page.render({ canvasContext, viewport });
+  const renderTask = page.render({
+    canvasContext,
+    viewport,
+    intent: opt.intent || "display",
+    background: opt.background || "rgb(255,255,255)",
+  });
 
   await renderTask.promise;
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,8 +1,8 @@
+import fs from "fs";
 import path from "path";
 import { pdfToImg } from ".";
 import { program, validatePrompts } from "./prompts";
 import { getPagesArray } from "./utils";
-import fs from "fs";
 
 program.parse(process.argv);
 
@@ -16,6 +16,8 @@ async function init() {
       imgType: opts.imgType,
       scale: opts.scale,
       pages: opts.pages,
+      intent: opts.intent as "display" | "print" | "any",
+      background: opts.background,
       documentOptions: {
         password: opts.password,
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
+import { PDFDocumentProxy } from "pdfjs-dist/types/src/display/api";
 import { CMAP_URL, STANDARD_FONT_DATA_URL } from "./constant";
 import { Options, PdfSrc, ReturnType } from "./types";
-import { PDFDocumentProxy } from "pdfjs-dist/types/src/display/api";
 import { defaultOptions, getPagesArray, isTypedArrayStrict } from "./utils";
 
 export function pdfToImg<O extends Options, S extends PdfSrc | PdfSrc[]>(
@@ -61,7 +61,12 @@ async function pageToImg(
     viewport.height,
   );
 
-  const renderTask = page.render({ canvasContext: context, viewport });
+  const renderTask = page.render({
+    canvasContext: context,
+    viewport,
+    background: opt.background || "rgb(255,255,255)",
+    intent: opt.intent || "display",
+  });
 
   await renderTask.promise;
 

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1,14 +1,16 @@
 import { Command } from "commander";
+import { PagesType } from "./types";
+import { defaultOptions } from "./utils";
 import {
+  validateBackground,
   validateImgType,
   validateInput,
+  validateIntent,
   validateNameTemplate,
   validateOutput,
   validatePages,
   validateScale,
 } from "./validators";
-import { defaultOptions } from "./utils";
-import { PagesType } from "./types";
 
 export const program = new Command();
 
@@ -42,6 +44,16 @@ program
   .option(
     "-ps, --password <password>",
     "Password for the PDF file if encrypted",
+  )
+  .option(
+    "-in, --intent <intent>",
+    "Rendering intent: 'display', 'print', or 'any'",
+    "display",
+  )
+  .option(
+    "-b, --background <color>",
+    "Background color (e.g., 'white', 'rgba(255,255,255,0.5)', '#ffffff')",
+    "rgb(255,255,255)",
   );
 
 export interface CLIOptions {
@@ -52,6 +64,8 @@ export interface CLIOptions {
   pages: string | number;
   name?: string;
   password?: string;
+  intent?: string;
+  background?: string;
 }
 
 export function validatePrompts(opts: CLIOptions) {
@@ -60,7 +74,8 @@ export function validatePrompts(opts: CLIOptions) {
   const imgType = validateImgType(opts.imgType) as "jpg" | "png";
   const scale = validateScale(String(opts.scale));
   const pages = validatePages(String(opts.pages)) as PagesType;
-
+  const intent = validateIntent(opts.intent || "display");
+  const background = validateBackground(opts.background || "rgb(255,255,255)");
   const nameTemplate = validateNameTemplate(inputPath, opts.name);
 
   return {
@@ -71,5 +86,7 @@ export function validatePrompts(opts: CLIOptions) {
     pages,
     nameTemplate,
     password: opts.password,
+    intent,
+    background,
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,9 +14,39 @@ export type PagesType =
   | number[];
 
 export interface Options {
+  /**
+   * The type of image to output. Can be 'png' or 'jpg'. The default value is 'png'.
+   */
   imgType?: "png" | "jpg";
+  /**
+   * The scale of the rendered image. The default value is 1.
+   */
   scale?: number;
+  /**
+   * Background to use for the canvas. Any valid canvas.fillStyle can be used:
+   * a DOMString parsed as CSS value, a CanvasGradient object (a linear or radial gradient)
+   * or a CanvasPattern object (a repetitive image).
+   * The default value is 'rgb(255,255,255)'.
+   */
+  background?: string | CanvasGradient | CanvasPattern | undefined;
+  /**
+   * Rendering intent, can be 'display', 'print', or 'any'. The default value is 'display'.
+   */
+  intent?: "display" | "print" | "any";
+  /**
+   * Specifies which pages to render from the PDF document. Can be:
+   * - A single page number (e.g. 1)
+   * - A page range object with optional startPage and endPage (e.g. {startPage: 1, endPage: 3})
+   * - "firstPage" to render only the first page
+   * - "lastPage" to render only the last page
+   * - "all" to render all pages
+   * - An array of specific page numbers (e.g. [1, 3, 5])
+   * @default "all"
+   */
   pages?: PagesType;
+  /**
+   * Additional document options.
+   */
   documentOptions?: DocumentParams;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,8 @@ export const defaultOptions: Required<Options> = {
   imgType: "png",
   pages: "all",
   scale: 1.0,
+  background: "rgb(255,255,255)",
+  intent: "display",
   documentOptions: {},
 };
 

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -1,5 +1,5 @@
-import path from "path";
 import fs from "fs";
+import path from "path";
 
 export function validateInput(value: string) {
   const inputPath = path.isAbsolute(value)
@@ -86,4 +86,20 @@ export function validateOutput(out?: string) {
     fs.mkdirSync(outputPath, { recursive: true });
   }
   return outputPath;
+}
+
+export function validateIntent(value: string) {
+  if (!["display", "print", "any"].includes(value)) {
+    throw new Error("Intent must be 'display', 'print', or 'any'.");
+  }
+  return value;
+}
+
+export function validateBackground(value: string) {
+  // For CLI, we'll only accept string values for background
+  // CanvasGradient and CanvasPattern are not applicable in CLI context
+  if (!value) {
+    return "rgb(255,255,255)"; // Default background
+  }
+  return value;
 }


### PR DESCRIPTION
# Add background and intent options to PDF rendering

## Description
This PR adds two new options to control PDF rendering:
- `background`: Allows setting a custom background color for the rendered images
- `intent`: Controls the rendering intent with options for 'display', 'print', or 'any'

## Changes
- Added new options to CLI interface with `-b/--background` and `-in/--intent` flags
- Implemented background and intent support in browser and Node.js interfaces
- Added validation for both new options
- Updated types and documentation
- Added example usage in example.ts

## Technical Details
- Background accepts any valid canvas.fillStyle value
- Intent options are 'display', 'print', or 'any'
- Default values:
  - Background: 'rgb(255,255,255)'
  - Intent: 'display'

## Backward Compatibility
This change is fully backward compatible as the default values match the previous behavior:
- Default background color ('rgb(255,255,255)') is the same as the original white background
- Default intent ('display') matches the original rendering behavior
- Existing code will continue to work without modification

## Example Usage
```typescript
const images = await pdfToImg(pdfBuffer, {
  scale: 2,
  background: "rgba(255,255,255,0)",
  intent: "print",
});
```